### PR TITLE
fix multiple @ in yarn list

### DIFF
--- a/server/actions/dependencies/add/add-project-dependencies.ts
+++ b/server/actions/dependencies/add/add-project-dependencies.ts
@@ -137,10 +137,12 @@ const getYarnPackageWithInfo = async (
   const type = getTypeFromPackageJson(projectPath, dependencyName);
   const required = getRequiredFromPackageJson(projectPath, dependencyName);
 
-  const info = installedInfo.find(
-    (x) => x.name.split('@')[0] === dependencyName,
-  );
-  const installed = info?.name.split('@')[1];
+  let atIndex = 0;
+  const info = installedInfo.find( (x) => {
+    atIndex = x.name.lastIndexOf('@');
+    return x.name.slice(0, atIndex) === dependencyName;
+  });
+  const installed = info?.name.slice(atIndex + 1);
 
   const wanted = getWantedVersion(
     installed,


### PR DESCRIPTION
While using Yarn, I discovered a code defect: 

x.name.split('@')[0] fails to properly extract the package name from a string like "@babel/generator@^7.21.5", resulting in an empty string instead of the expected package name and causing an error. 

Therefore, I have submitted a fix for this issue.